### PR TITLE
update default report version

### DIFF
--- a/appstoreconnect/api.py
+++ b/appstoreconnect/api.py
@@ -650,9 +650,9 @@ class Api:
         # setup required filters if not provided
         default_versions = {
             "SALES": "1_0",
-            "SUBSCRIPTION": "1_2",
-            "SUBSCRIPTION_EVENT": "1_2",
-            "SUBSCRIBER": "1_2",
+            "SUBSCRIPTION": "1_3",
+            "SUBSCRIPTION_EVENT": "1_3",
+            "SUBSCRIBER": "1_3",
             "NEWSSTAND": "1_0",
             "PRE_ORDER": "1_0",
         }


### PR DESCRIPTION
from the [apple documentation](https://developer.apple.com/documentation/appstoreconnectapi/download_sales_and_trends_reports)

> Version 1_2 of the Subscription, Subscription Event, and Subscriber reports in Sales and Trends is no longer available for download.